### PR TITLE
Fix build system in Dockerfile and NaN propagation in centroiding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,44 +44,21 @@ RUN pip3 install --no-cache-dir \
 WORKDIR /workspace
 
 # Copy entire project
-COPY rippra/ ./rippra/
-COPY docs/    ./docs/
-COPY config/  ./config/
+COPY . .
 
-# Build C library (static)
-WORKDIR /workspace/rippra
-RUN mkdir -p bin && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/centroid.c -o bin/centroid.o && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/io.c -o bin/io.o && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/la.c -o bin/la.o && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/recon.c -o bin/recon.o && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/stream.c -o bin/stream.o && \
-    gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c src/rippra_api.c -o bin/rippra_api.o && \
-    gcc -shared -fopenmp -o bin/librippra.so \
-        bin/centroid.o bin/io.o bin/la.o bin/recon.o bin/stream.o bin/rippra_api.o && \
-    echo "Build complete"
-
-# Build test programs
-RUN gcc -std=c99 -Wall -Wextra -O2 -fopenmp -DNDEBUG \
-        -Iinclude -c tests/test_recon.c -o bin/test_recon.o && \
-    gcc -fopenmp -o bin/test_recon \
-        bin/test_recon.o bin/centroid.o bin/io.o bin/la.o bin/recon.o bin/stream.o && \
-    echo "Test binaries built"
+# Build C library and tests using CMake
+RUN cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build
 
 # Export ONNX models
-RUN cd ml && python3 export_onnx.py --output_dir /workspace/rippra/onnx_models && \
+RUN cd rippra/ml && python3 export_onnx.py --output_dir /workspace/rippra/onnx_models && \
     echo "ONNX export complete"
 
 # Run baseline tests
 RUN echo "=== Testing C reconstructor ===" && \
-    ./bin/test_recon && \
+    ./build/test_recon && \
     echo "=== C tests passed ==="
 
 # Default command
 CMD ["/bin/bash"]
+

--- a/rippra/src/centroid.c
+++ b/rippra/src/centroid.c
@@ -399,10 +399,16 @@ void rippa_compute_deltas(const double *cx, const double *cy,
     int i;
     (void)nspots;
     for (i = 0; i < cal->nspots; ++i) {
-        dx[i] = cx[i] - cal->subaps[i].ref_cx;
-        dy[i] = cy[i] - cal->subaps[i].ref_cy;
+        if (isnan(cx[i]) || isnan(cy[i])) {
+            dx[i] = 0.0;
+            dy[i] = 0.0;
+        } else {
+            dx[i] = cx[i] - cal->subaps[i].ref_cx;
+            dy[i] = cy[i] - cal->subaps[i].ref_cy;
+        }
     }
 }
+
 
 int rippa_compute_centroids_refined(const double *frame, int width, int height,
                                      const rippra_calibration *cal,


### PR DESCRIPTION
# Pull Request: Resolve Docker Build System & Numerical Safety Defects

This pull request resolves the remaining legitimate issues identified by the system audits (**Issue #4** and **Issue #5**). It refactors the containerized build pipeline to use the standardized CMake build files and implements crucial numerical safety guards to prevent NaN propagation inside the wavefront reconstruction solver.

---

## Detailed Changes

### 1. Build System Modernization & Dockerfile Refactoring (Resolves #4)
* **Problem**: The project previously relied on hardcoded `gcc` manual compilation loops inside the `Dockerfile`, making it difficult to maintain, verify, or integrate cross-platform build options (e.g. OpenBLAS, LAPACK, CUDA).
* **Solution**:
  * Refactored [Dockerfile](file:///d:/Project%20RIPRA%20(%E0%A4%8B%E0%A4%AA%E0%A5%8D%E0%A4%B0)/Dockerfile) to copy the entire repository root (to ensure `CMakeLists.txt` is in the build context) rather than copying individual directories.
  * Replaced manual compilation steps with standardized CMake build commands:
    ```dockerfile
    RUN cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && \
        cmake --build build
    ```
  * Updated the container test verification target to execute `./build/test_recon` (compiled dynamically via CMake) instead of the old manual path `./bin/test_recon`.

### 2. Numerical Safety Defect: NaN Propagation Guard (Resolves #5)
* **Problem**: When a sub-aperture was invalid (e.g., occluded lenslets or edge-cut spots below threshold), the centroiding algorithm correctly assigned `NAN` to the spot coordinates (`cx`, `cy`). However, subtracting the reference centers resulted in `NAN` displacements (`dx`, `dy`). Since the reconstruction step performs a matrix-vector multiplication ($\mathbf{W} = \mathbf{G}_{pinv} \cdot \mathbf{s}$), a single `NAN` in the slope vector mutated the **entire** reconstructed phase heights vector ($\mathbf{W}$) to `NAN`.
* **Solution**:
  * Implemented an explicit `isnan()` check in the centroid delta computation inside [rippra/src/centroid.c](file:///d:/Project%20RIPRA%20(%E0%A4%8B%E0%A4%AA%E0%A5%8D%E0%A4%B0)/rippra/src/centroid.c#L395-L405).
  * If a spot's centroids contain `NAN` values, the corresponding slope displacements `dx[i]` and `dy[i]` are set to `0.0` (which effectively treats the invalid sub-aperture as having no wavefront aberration, allowing the rest of the wavefront matrix solvers to complete successfully without numerical corruption):
    ```c
    if (isnan(cx[i]) || isnan(cy[i])) {
        dx[i] = 0.0;
        dy[i] = 0.0;
    } else {
        dx[i] = cx[i] - cal->subaps[i].ref_cx;
        dy[i] = cy[i] - cal->subaps[i].ref_cy;
    }
    ```

---

## Verification and Testing
* Validated that the C library compiles cleanly via CMake.
* Verified that the test executable runs successfully on the default synthetic calibration frames, showing zero regressions in reconstructor accuracy or execution speeds.

Closes #4
Closes #5
