### PR TITLE
chore: add Dependabot config for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/rippra/ml"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #44

Adds a .github/dependabot.yml configuration with weekly update checks for:
- **pip** ecosystem under /rippra/ml (Python dependencies)
- **github-actions** ecosystem at / (workflow dependencies)

The CodeQL workflow (other half of #44) already existed and was fixed in previous commits.