### PR TITLE
fix: guard division-by-zero in tau0 fractional-lag interpolation (closes #17)

### DIFF
--- a/rippra/src/recon.c
+++ b/rippra/src/recon.c
@@ -495,7 +495,15 @@ double rippra_compute_tau0_impl(const double *dx_series, const double *dy_series
         /* Interpolate fractional lag */
         double C_prev = C[found_lag - 1];
         double C_curr = C[found_lag];
-        double fraction = (target - C_prev) / (C_curr - C_prev);
+        double denom = C_curr - C_prev;
+        double fraction;
+        double scale = fabs(C_curr) > fabs(C_prev) ? fabs(C_curr) : fabs(C_prev);
+        if (fabs(denom) < 1e-12 * (scale > 1e-12 ? scale : 1.0)) {
+            /* Degenerate/flat autocorrelation — can't interpolate; use midpoint. */
+            fraction = 0.5;
+        } else {
+            fraction = (target - C_prev) / denom;
+        }
         double float_lag = (found_lag - 1) + fraction;
         tau0 = float_lag / frame_rate;
     } else {

--- a/rippra/tests/test_recon.c
+++ b/rippra/tests/test_recon.c
@@ -150,6 +150,42 @@ int main(void) {
     free(dx_series);
     free(dy_series);
 
+    /* 4b. Degenerate (flat) tau0 test — guard against div-by-zero */
+    {
+        printf("\n4b. Degenerate tau0 (flat autocorrelation)...\n");
+        int nf = 50;
+        double *dx_flat = (double *)calloc(nf * cal.nspots, sizeof(double));
+        double *dy_flat = (double *)calloc(nf * cal.nspots, sizeof(double));
+        /* All zero — perfectly flat autocorrelation, no decay */
+        for (int t = 0; t < nf; ++t) {
+            for (int k = 0; k < cal.nspots; ++k) {
+                dx_flat[t * cal.nspots + k] = 0.0;
+                dy_flat[t * cal.nspots + k] = 0.0;
+            }
+        }
+        double tau0_flat = rippra_compute_tau0_impl(dx_flat, dy_flat, nf, cal.nspots, 1000.0);
+        int flat_ok = isfinite(tau0_flat) && tau0_flat >= 0.0;
+        printf("   tau0 (flat input) = %.4f ms  %s\n",
+               tau0_flat * 1000.0, flat_ok ? "OK" : "FAIL (NaN/inf)");
+        /* Also test with identical (non-zero) values */
+        for (int t = 0; t < nf; ++t) {
+            for (int k = 0; k < cal.nspots; ++k) {
+                dx_flat[t * cal.nspots + k] = 1.0;
+                dy_flat[t * cal.nspots + k] = 1.0;
+            }
+        }
+        double tau0_ident = rippra_compute_tau0_impl(dx_flat, dy_flat, nf, cal.nspots, 1000.0);
+        int ident_ok = isfinite(tau0_ident) && tau0_ident >= 0.0;
+        printf("   tau0 (identical input) = %.4f ms  %s\n",
+               tau0_ident * 1000.0, ident_ok ? "OK" : "FAIL (NaN/inf)");
+        free(dx_flat);
+        free(dy_flat);
+        if (!flat_ok || !ident_ok) {
+            printf("ERROR: tau0 div-by-zero guard FAILED\n");
+            return 1;
+        }
+    }
+
     /* 5. DM Command Mapping */
     printf("\n5. Deformable Mirror Actuator Mapping...\n");
     double *dm_cmds = (double *)calloc(mesh.nnodes, sizeof(double));


### PR DESCRIPTION
## Summary

Guards against division-by-zero in \ippra_compute_tau0_impl\ when the auto-correlation curve is flat (degenerate input), which would produce NaN/inf tau0 silently.

## Bug

In \ippra/src/recon.c:498\:
\\\c
double fraction = (target - C_prev) / (C_curr - C_prev);
\\\
When \C_curr == C_prev\ (flat/degenerate autocorrelation, e.g. all-zero or all-identical input), this is division by zero → NaN.

## Fix

- Check if the denominator \C_curr - C_prev\ is effectively zero using a combined relative + absolute epsilon
- If degenerate, fall back to \raction = 0.5\ (midpoint between lags)
- Added unit test in \	est_recon.c\ with both zero and identical-input degenerate cases

## Verification

- \	est_recon\: Both degenerate cases now return finite values (0.5 ms and 24.0 ms) instead of NaN
- \	est_full_pipeline\: 35/35 tests still pass
- Clean compile with no warnings

Closes #17