### PR TITLE
feat: report SVD non-convergence / condition number from la.c pseudo-inverse

### DIFF
--- a/rippra/include/rippra/la.h
+++ b/rippra/include/rippra/la.h
@@ -58,10 +58,15 @@ int rippa_lusolve(double *A, double *b, size_t n);
  * zeroed (treated as null space). This is what makes the piston mode drop
  * out automatically for the geometry/interaction matrices.
  *
- * Returns 0 on success. Aplus must hold at least m*n doubles.
+ * If cond is non-NULL, the condition number (smax / smin) of the non-truncated
+ * singular values is stored there. If all values are truncated, *cond = 0.
+ *
+ * Returns 0 on success (converged), -1 if SVD did not converge within max
+ * sweeps, -2 on memory allocation failure. Aplus must hold at least m*n
+ * doubles.
  */
 int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
-               double rcond);
+               double rcond, double *cond);
 
 #ifdef __cplusplus
 }

--- a/rippra/include/rippra/recon.h
+++ b/rippra/include/rippra/recon.h
@@ -21,6 +21,7 @@ typedef struct rippra_zonal_mesh {
     int *node_v;      /* v-coordinate (row) on the lenslet grid */
     double *G;        /* Geometry matrix, size (2 * nspots) x nnodes, row-major */
     double *Gpinv;    /* Pseudo-inverse of G, size nnodes x (2 * nspots), row-major */
+    double cond;      /* condition number of G (smax/smin of non-truncated singular values) */
 } rippra_zonal_mesh;
 
 /*
@@ -35,6 +36,7 @@ typedef struct rippra_modal_model {
     int *mode_m;      /* Azimuthal order m for each active mode */
     double *Zprime;   /* Zernike derivative matrix, size (2 * nspots) x nmodes, row-major */
     double *Zprime_pinv; /* Pseudo-inverse, size nmodes x (2 * nspots), row-major */
+    double cond;      /* condition number of Zprime (smax/smin of non-truncated singular values) */
 } rippra_modal_model;
 
 /*

--- a/rippra/src/la.c
+++ b/rippra/src/la.c
@@ -149,16 +149,17 @@ int rippa_lusolve(double *A, double *b, size_t n)
  * We then build A+ = V * diag(1/sigma) * U^T with rcond truncation.
  */
 int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
-               double rcond)
+               double rcond, double *cond)
 {
     const int maxsweeps = 60;
     const double tol = 1e-14;
-    int sweep, p, q, i, ok;
+    int sweep, p, q, i;
     double *W;   /* working copy of A, m x n, mutated to hold U*sigma        */
     double *V;   /* n x n right singular vectors                              */
     double *sig; /* n singular values                                        */
     size_t mn = (size_t)m * (size_t)n;
     size_t nn = (size_t)n * (size_t)n;
+    int converged = 0;
 
     W = (double *)malloc(mn * sizeof(double));
     V = (double *)malloc(nn * sizeof(double));
@@ -209,12 +210,13 @@ int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
                 }
             }
         }
-        if (!off) break; /* converged */
+        if (!off) { converged = 1; break; } /* converged */
     }
 
     /* singular values = column norms of W; scale W down to U */
     {
         double smax = 0.0;
+        double smin = 1e300;
         for (p = 0; p < (int)n; ++p) {
             double nnrm = 0.0;
             for (i = 0; i < (int)m; ++i)
@@ -239,8 +241,14 @@ int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
                 if (sig[p] < thresh) {
                     for (i = 0; i < (int)m; ++i)
                         W[i * n + p] = 0.0;
+                } else if (sig[p] < smin) {
+                    smin = sig[p];
                 }
             }
+        }
+        /* Condition number = smax / smin (0 if all truncated) */
+        if (cond) {
+            *cond = (smax > 0.0 && smin < 1e299) ? smax / smin : 0.0;
         }
     }
 
@@ -249,7 +257,6 @@ int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
      * then A+ (n x m) = Vscaled (n x n) * U^T (n x m).
      * U^T[p][i] = U[i][p] = W[i*n+p].
      */
-    ok = 0;
     {
         double *Vscaled = (double *)malloc(nn * sizeof(double));
         if (!Vscaled) { free(W); free(V); free(sig); return -2; }
@@ -272,5 +279,5 @@ int rippa_pinv(const double *A, double *Aplus, size_t m, size_t n,
     }
 
     free(W); free(V); free(sig);
-    return ok;
+    return converged ? 0 : -1;
 }

--- a/rippra/src/recon.c
+++ b/rippra/src/recon.c
@@ -243,8 +243,10 @@ int rippra_zonal_setup(const rippra_calibration *cal, const rippa_config *cfg, r
     
     /* Compute pseudo-inverse of G (size 2*nspots x nnodes) -> Gpinv (size nnodes x 2*nspots) */
     /* Singular values below rcond * max_sig are truncated to remove piston */
-    int rc = rippa_pinv(mesh->G, mesh->Gpinv, 2 * nspots, nnodes, 1e-4);
+    double zcond = 0.0;
+    int rc = rippa_pinv(mesh->G, mesh->Gpinv, 2 * nspots, nnodes, 1e-4, &zcond);
     if (rc != 0) return -3;
+    mesh->cond = zcond;
     
     return 0;
 }
@@ -353,8 +355,10 @@ int rippra_modal_setup(const rippra_calibration *cal, const rippa_config *cfg, r
     }
     
     /* Compute pseudo-inverse of Zprime */
-    int rc = rippa_pinv(model->Zprime, model->Zprime_pinv, 2 * nspots, nmodes, 1e-4);
+    double zcond = 0.0;
+    int rc = rippa_pinv(model->Zprime, model->Zprime_pinv, 2 * nspots, nmodes, 1e-4, &zcond);
     if (rc != 0) return -2;
+    model->cond = zcond;
     
     return 0;
 }

--- a/rippra/tests/test_full_pipeline.c
+++ b/rippra/tests/test_full_pipeline.c
@@ -199,6 +199,7 @@ int main(void)
     ret = rippra_zonal_setup(&cal, &cfg, &zmesh);
     TEST(ret == 0, "Zonal mesh setup");
     if (ret == 0) {
+        printf("  Zonal G cond: %.2f\n", zmesh.cond);
         phase = (double*)malloc(zmesh.nnodes * sizeof(double));
         ret = rippra_zonal_reconstruct(&zmesh, dx, dy, &cfg, phase);
         TEST(ret == 0, "Zonal reconstruction");
@@ -217,6 +218,7 @@ int main(void)
     TEST(ret == 0, "Modal model setup");
     nmodes = mmodel.nmodes;
     if (ret == 0 && nmodes > 0) {
+        printf("  Modal Zprime cond: %.2f\n", mmodel.cond);
         coeffs = (double*)malloc(nmodes * sizeof(double));
         ret = rippra_modal_reconstruct(&mmodel, dx, dy, &cfg, coeffs);
         TEST(ret == 0, "Modal reconstruction");

--- a/rippra/tests/test_la.c
+++ b/rippra/tests/test_la.c
@@ -58,8 +58,10 @@ static void test_pinv_identity(void)
 {
     double A[4] = {1,0, 0,1};
     double Ap[4];
-    int rc = rippa_pinv(A, Ap, 2, 2, 1e-12);
+    double cond_id = 0.0;
+    int rc = rippa_pinv(A, Ap, 2, 2, 1e-12, &cond_id);
     check("pinv_id_rc", (double)rc, 0.0, 0.0);
+    check("pinv_id_cond", cond_id, 1.0, 1e-10);
     check("pinv_id_00", Ap[0], 1.0, 1e-10);
     check("pinv_id_01", Ap[1], 0.0, 1e-10);
     check("pinv_id_10", Ap[2], 0.0, 1e-10);
@@ -72,7 +74,8 @@ static void test_pinv_tall(void)
     /* A = [1 0; 0 2; 3 1] */
     double A[6] = {1,0, 0,2, 3,1};
     double Ap[6];  /* 2x3 */
-    int rc = rippa_pinv(A, Ap, 3, 2, 1e-12);
+    double cond_tall = 0.0;
+    int rc = rippa_pinv(A, Ap, 3, 2, 1e-12, &cond_tall);
     check("pinv_tall_rc", (double)rc, 0.0, 0.0);
     /* A * A+ should be 3x3 projection; A+ * A should be 2x2 identity */
     /* Check A+ * A = I (2x2) */
@@ -92,7 +95,8 @@ static void test_pinv_truncated(void)
     /* A = [1 1; 1 1; 0 0] — rank 1, sigma = [2, 0] */
     double A[6] = {1,1, 1,1, 0,0};
     double Ap[6];
-    int rc = rippa_pinv(A, Ap, 3, 2, 1e-6);
+    double cond_trunc = 0.0;
+    int rc = rippa_pinv(A, Ap, 3, 2, 1e-6, &cond_trunc);
     check("pinv_trunc_rc", (double)rc, 0.0, 0.0);
     /* A * A+ * A ≈ A */
     {

--- a/rippra/tests/test_recon.c
+++ b/rippra/tests/test_recon.c
@@ -70,6 +70,7 @@ int main(void) {
         return 1;
     }
     printf("   Unique phase nodes generated: %d\n", mesh.nnodes);
+    printf("   Condition number of G: %.2f\n", mesh.cond);
     
     double *W = (double *)calloc(mesh.nnodes, sizeof(double));
     rc = rippra_zonal_reconstruct(&mesh, dx, dy, &cfg, W);
@@ -107,6 +108,7 @@ int main(void) {
         printf("ERROR: Modal setup failed (rc=%d)\n", rc);
     } else {
         printf("   Zernike modes to estimate (radial order <= %d): %d\n", cfg.zernike_nmax, model.nmodes);
+        printf("   Condition number of Zprime: %.2f\n", model.cond);
         
         double *coeffs = (double *)calloc(model.nmodes, sizeof(double));
         rc = rippra_modal_reconstruct(&model, dx, dy, &cfg, coeffs);


### PR DESCRIPTION
Closes #21

## Summary
- Extended \ippa_pinv\ signature with optional \double *cond\ output parameter (NULL-safe)
- Returns condition number = smax/smin of non-truncated singular values
- Returns 0 on convergence, -1 on non-convergence within 60 sweeps, -2 on OOM
- \ippra_zonal_mesh\ and \ippra_modal_model\ structs gain \double cond\ field
- Condition numbers printed in test output (zonal G: 8.27, modal Zprime: 7.66)
- All 37/37 pipeline tests + 28/28 LA tests pass