### PR TITLE
docs: add Known Assumptions and Simplifications section to README and paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,23 @@ Open `notebook/kaggle_synthetic_shwfs_generator.ipynb` to customize parameters, 
 
 ### 2. Spot Deviation on Detector due to Distorted Wavefront
 ![Spot Deviation](./visualizations/Schematic%20showing%20spot%20deviation%20on%20detector%20due%20to%20distorted%20wavefront.webp)
+## Known Assumptions and Simplifications
+
+The following simplifications are documented for reviewers and downstream users:
+
+### DM Coupling Model
+The inter-actuator coupling matrix uses a **geometric nearest-neighbor model** — self-coupling 1.0, adjacent-actuator coupling by the configurable `coupling` coefficient, and diagonal coupling by `coupling²`. This is not a measured influence function. See `rippra/src/recon.c` (`rippra_dm_setup`, `rippra_dm_map`).
+
+A physical DM requires either manufacturer-provided influence matrices or interferometric calibration to replace this model.
+
+### Turbulence Data
+All training and evaluation datasets are **synthetically generated** using a Kolmogorov turbulence model with Taylor frozen-flow temporal evolution (AR(1)). This has not been validated against experimental atmospheric data. See `rippra/ml/synthetic_shwfs.py`.
+
+When real SH-WFS measurements become available, the synthetic data generation parameters should be re-calibrated.
+
+### Latency Benchmarks
+Performance figures reported are from **microbenchmarks** on a desktop system (see [Performance Documentation](docs/performance.md)). A production AO pipeline incurs additional overhead from camera readout, DMA transfers, and DM DAC settling times not modeled here.
+
 ## Acknowledgements
 
 - ISRO Bharatiya Antariksh Hackathon 2026 for the problem statement and evaluation framework.

--- a/docs/paper/rippra_paper.tex
+++ b/docs/paper/rippra_paper.tex
@@ -333,6 +333,20 @@ The pipeline dashboard (\texttt{pipeline\_dashboard.html}) is a self-contained H
 
 Additional dashboards provide Zernike modal weight tracking (20 coefficients), low-order time-series (500 frames), turbulence telemetry ($r_0$, $\tau_0$), regime classification, and a 6-panel system performance monitor.
 
+\section{Known Assumptions and Simplifications}
+\label{sec:assumptions}
+
+The following simplifying assumptions are made in this work and should be noted before deployment on real hardware:
+
+\paragraph{DM Coupling Model (Section~\ref{sec:dm}):}
+The inter-actuator coupling matrix $\mathbf{M}$ is modeled as a geometric nearest-neighbor rule: self-coupling~1.0, adjacent-actuator coupling~$\gamma$, and diagonal-actuator coupling~$\gamma^2$ (see \texttt{recon.c}, \texttt{rippra\_dm\_setup}). A physical DM's influence function deviates from this idealization and requires either manufacturer-provided influence matrices or interferometric calibration.
+
+\paragraph{Turbulence Data (Section~\ref{sec:dataset}):}
+All training and evaluation data are generated synthetically from a Kolmogorov model with Taylor frozen-flow temporal evolution (AR(1) process). The synthetic pipeline (see \texttt{synthetic\_shwfs.py}) has not been validated against experimental atmospheric data. When real SH-WFS measurements become available, the synthetic data generation parameters should be re-calibrated.
+
+\paragraph{Latency Benchmarks (Section~\ref{sec:perf}):}
+Performance figures presented in this paper are obtained from microbenchmarks on a desktop system (Section~\ref{sec:impl}). A production AO pipeline incurs additional overhead from camera readout, DMA transfers, and DM DAC settling times that are not modeled here.
+
 \section{Conclusion}
 \label{sec:conclusion}
 


### PR DESCRIPTION
- Fixes #33
- DM coupling: geometric nearest-neighbor model (not measured influence function)
- Turbulence: synthetic Kolmogorov data (not validated against real atmosphere)
- Latency: microbenchmarks only (not including camera/DMA/DM overhead)
- Each assumption cross-referenced to the source file and function that encodes it